### PR TITLE
feat: store is required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     env:
       MYSQL_DB_DATABASE: keyv_test

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "ts-standard": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "packages/**"

--- a/packages/compress/package.json
+++ b/packages/compress/package.json
@@ -40,7 +40,7 @@
     "delay": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "typescript": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,13 +5,14 @@ const JSONB = require('json-buffer')
 
 class Keyv extends EventEmitter {
   constructor (options = {}) {
+    if (!options.store) throw new TypeError('An `store` should be provided.')
+
     super()
 
     Object.entries(Object.assign(
       {
         serialize: JSONB.stringify,
-        deserialize: JSONB.parse,
-        store: new Map()
+        deserialize: JSONB.parse
       },
       options
     )).forEach(([key, value]) => (this[key] = value))

--- a/packages/core/test/keyv.js
+++ b/packages/core/test/keyv.js
@@ -8,8 +8,12 @@ const Keyv = require('..')
 
 test.serial('Keyv is a class', t => {
   t.is(typeof Keyv, 'function')
-  t.throws(() => Keyv()) // eslint-disable-line new-cap
-  t.notThrows(() => new Keyv())
+  t.throws(() => Keyv({ store: new Map() })) // eslint-disable-line new-cap
+  t.notThrows(() => new Keyv({ store: new Map() }))
+})
+
+test.serial('store is required', t => {
+  t.throws(() => new Keyv())
 })
 
 test.serial('Keyv accepts storage adapters', async t => {
@@ -158,14 +162,14 @@ test.serial('An empty namespace stores the key as a string', async t => {
 })
 
 test('emit errors by default', async t => {
-  const store = new Keyv()
+  const store = new Keyv({ store: new Map() })
   const keyv = new Keyv({ store, namespace: '' })
   await keyv.set(42, 'foo')
   t.is(store.listenerCount('error'), 1)
 })
 
 test('disable emit errors', async t => {
-  const store = new Keyv({ emitErrors: false })
+  const store = new Keyv({ store: new Map(), emitErrors: false })
   const keyv = new Keyv({ store, emitErrors: false, namespace: '' })
   await keyv.set(42, 'foo')
   t.is(keyv.listenerCount('error'), 0)

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -35,7 +35,7 @@
     "delay": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -42,7 +42,7 @@
     "typescript": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/multi/package.json
+++ b/packages/multi/package.json
@@ -36,7 +36,7 @@
     "delay": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -43,7 +43,7 @@
     "typescript": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/offline/package.json
+++ b/packages/offline/package.json
@@ -39,7 +39,7 @@
     "keyv-s3": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -43,7 +43,7 @@
     "typescript": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -42,7 +42,7 @@
     "typescript": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -39,7 +39,7 @@
     "pify": "5"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -43,7 +43,7 @@
     "typescript": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -32,7 +32,7 @@
     "timekeeper": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "files": [
     "src"


### PR DESCRIPTION
The absence of passing a `store` has been translated until now as a user desire of using an in-memory store.

Although that could be a conscious decision, that default behavior is not helping in order to learn and understand how Keyv works, and how you can get to benefit of the ecosystem of different connectors.

Plus, always could be possible you don't pass it because you forgot about it.

This PR make changes to that behavior, doing required to explicitly pass a store connector, and make the user conscience about it.

```js
const Keyv = require('@keyvhq/core')

// before
const keyv = new Keyv()

// after
const keyv = new Keyv() // => 'TypeError: `store` is required'

// good
const keyv = new Keyv({ store: new Map() })
```