### PR TITLE
feat: remove EventEmitter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     env:
       MYSQL_DB_DATABASE: keyv_test

--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ You should also set a [`namespace`](#optionsnamespace) for your module so you ca
 
 Returns a new Keyv instance.
 
-The Keyv instance is also an `EventEmitter` that will emit an `'error'` event if the storage adapter connection fails.
-
 #### options
 
 Type: `Object`

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -5,9 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { EventEmitter } from 'events'
-
-declare class Keyv<TValue = any> extends EventEmitter {
+declare class Keyv<TValue = any> {
   constructor (opts?: Keyv.Options<TValue>)
 
   /** Returns the value. */

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,31 +1,27 @@
 'use strict'
 
-const EventEmitter = require('events')
 const JSONB = require('json-buffer')
 
-class Keyv extends EventEmitter {
+class Keyv {
   constructor (options = {}) {
-    super()
-
-    Object.entries(Object.assign(
-      {
-        serialize: JSONB.stringify,
-        deserialize: JSONB.parse,
-        store: new Map()
-      },
-      options
-    )).forEach(([key, value]) => (this[key] = value))
-
-    if (typeof this.store.on === 'function') {
-      this.store.on('error', error => this.emit('error', error))
-    }
+    Object.entries(
+      Object.assign(
+        {
+          serialize: JSONB.stringify,
+          deserialize: JSONB.parse,
+          store: new Map()
+        },
+        options
+      )
+    ).forEach(([key, value]) => (this[key] = value))
 
     const generateIterator = iterator =>
       async function * () {
         for await (const [key, raw] of typeof iterator === 'function'
           ? iterator(this.namespace)
           : iterator) {
-          const data = typeof raw === 'string' ? await this.deserialize(raw) : raw
+          const data =
+            typeof raw === 'string' ? await this.deserialize(raw) : raw
           if (this.namespace && !key.includes(this.namespace)) {
             continue
           }
@@ -51,7 +47,9 @@ class Keyv extends EventEmitter {
   }
 
   _getKeyPrefix (key) {
-    return this.namespace ? `${this.namespace}:${key}` : (key && key.toString()) || key
+    return this.namespace
+      ? `${this.namespace}:${key}`
+      : (key && key.toString()) || key
   }
 
   _getKeyUnprefix (key) {
@@ -73,7 +71,9 @@ class Keyv extends EventEmitter {
   }
 
   async has (key) {
-    return typeof this.store.has === 'function' ? this.store.has(this._getKeyPrefix(key)) : (await this.store.get(this._getKeyPrefix(key))) !== undefined
+    return typeof this.store.has === 'function'
+      ? this.store.has(this._getKeyPrefix(key))
+      : (await this.store.get(this._getKeyPrefix(key))) !== undefined
   }
 
   async set (key, value, ttl) {

--- a/packages/core/test/keyv.js
+++ b/packages/core/test/keyv.js
@@ -157,19 +157,5 @@ test.serial('An empty namespace stores the key as a string', async t => {
   t.is([...store.keys()][0], '42')
 })
 
-test('emit errors by default', async t => {
-  const store = new Keyv()
-  const keyv = new Keyv({ store, namespace: '' })
-  await keyv.set(42, 'foo')
-  t.is(store.listenerCount('error'), 1)
-})
-
-test('disable emit errors', async t => {
-  const store = new Keyv({ emitErrors: false })
-  const keyv = new Keyv({ store, emitErrors: false, namespace: '' })
-  await keyv.set(42, 'foo')
-  t.is(keyv.listenerCount('error'), 0)
-})
-
 const store = () => new Map()
 keyvTestSuite(test, Keyv, store)

--- a/packages/core/test/keyv.test-d.ts
+++ b/packages/core/test/keyv.test-d.ts
@@ -35,9 +35,6 @@ new Keyv();
 
 (async () => {
   const keyv = new Keyv<string>()
-
-  keyv.on('error', err => console.log('Connection Error', err))
-
   expectType<boolean>(await keyv.set('foo', 'expires in 1 second', 1000))
   expectType<boolean>(await keyv.set('foo', 'never expires'))
   expectType<string | undefined>(await keyv.get('foo'))

--- a/packages/memoize/test/index.js
+++ b/packages/memoize/test/index.js
@@ -58,7 +58,7 @@ test('should delete store value after expiration', async t => {
   const ttl = 100
   await keyv.set(5, 5, ttl)
 
-  const memoizedSum = memoize(asyncSum, keyv, { ttl: ttl })
+  const memoizedSum = memoize(asyncSum, keyv, { ttl })
 
   t.is(await memoizedSum(5), 5)
 

--- a/packages/mongo/src/index.d.ts
+++ b/packages/mongo/src/index.d.ts
@@ -5,10 +5,9 @@
 // TypeScript Version: 2.3
 
 import { Store } from '@keyvhq/core'
-import { EventEmitter } from 'events'
 import { MongoClientOptions } from 'mongodb'
 
-declare class KeyvMongo<TValue> extends EventEmitter implements Store<TValue> {
+declare class KeyvMongo<TValue> implements Store<TValue> {
   readonly ttlSupport: false
   namespace?: string | undefined
 

--- a/packages/mongo/src/index.js
+++ b/packages/mongo/src/index.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const EventEmitter = require('events')
 const mongodb = require('mongodb')
 const pify = require('pify')
 
 const keyvMongoKeys = ['url', 'collection', 'emitErrors']
-class KeyvMongo extends EventEmitter {
+class KeyvMongo {
   constructor (url, options) {
-    super()
     this.ttlSupport = false
     url = url || {}
     if (typeof url === 'string') {
@@ -23,8 +21,7 @@ class KeyvMongo extends EventEmitter {
         url: 'mongodb://127.0.0.1:27017',
         collection: 'keyv',
         useNewUrlParser: true,
-        useUnifiedTopology: true,
-        emitErrors: true
+        useUnifiedTopology: true
       },
       url,
       options
@@ -35,11 +32,7 @@ class KeyvMongo extends EventEmitter {
         ([k, v]) => !keyvMongoKeys.includes(k)
       )
     )
-    try {
-      this.client = new mongodb.MongoClient(this.options.url, mongoOptions)
-    } catch (error) {
-      if (this.options.emitErrors) this.emit('error', error)
-    }
+    this.client = new mongodb.MongoClient(this.options.url, mongoOptions)
 
     this.mongo = {}
     let listeningEvents = false

--- a/packages/mongo/test/index.js
+++ b/packages/mongo/test/index.js
@@ -16,8 +16,7 @@ test('Collection option merges into default options', t => {
     url: 'mongodb://127.0.0.1:27017',
     useNewUrlParser: true,
     useUnifiedTopology: true,
-    collection: 'foo',
-    emitErrors: true
+    collection: 'foo'
   })
 })
 
@@ -27,7 +26,6 @@ test('Collection option merges into default options if URL is passed', t => {
     url: mongoURL,
     useNewUrlParser: true,
     useUnifiedTopology: true,
-    collection: 'foo',
-    emitErrors: true
+    collection: 'foo'
   })
 })

--- a/packages/mysql/src/index.d.ts
+++ b/packages/mysql/src/index.d.ts
@@ -5,9 +5,8 @@
 // TypeScript Version: 2.3
 
 import { Store } from '@keyvhq/core'
-import { EventEmitter } from 'events'
 
-declare class KeyvMysql extends EventEmitter implements Store<string | undefined> {
+declare class KeyvMysql implements Store<string | undefined> {
   readonly ttlSupport: false
   namespace?: string | undefined
 

--- a/packages/postgres/src/index.d.ts
+++ b/packages/postgres/src/index.d.ts
@@ -5,9 +5,8 @@
 // TypeScript Version: 2.3
 
 import { Store } from '@keyvhq/core'
-import { EventEmitter } from 'events'
 
-declare class KeyvPostgres extends EventEmitter implements Store<string | undefined> {
+declare class KeyvPostgres implements Store<string | undefined> {
   readonly ttlSupport: false
   namespace?: string | undefined
 

--- a/packages/redis/src/index.d.ts
+++ b/packages/redis/src/index.d.ts
@@ -6,9 +6,8 @@
 
 import { Store } from '@keyvhq/core'
 import { Redis, RedisOptions } from 'ioredis'
-import { EventEmitter } from 'events'
 
-declare class KeyvRedis extends EventEmitter implements Store<string | undefined> {
+declare class KeyvRedis implements Store<string | undefined> {
   readonly ttlSupport: true
   namespace?: string | undefined
 

--- a/packages/redis/src/index.js
+++ b/packages/redis/src/index.js
@@ -1,35 +1,21 @@
 'use strict'
 
-const EventEmitter = require('events')
 const pEvent = require('p-event')
 const Redis = require('ioredis')
 
-const normalizeOptions = (...args) =>
-  Object.assign({ emitErrors: true }, ...args)
-
 const normalizeArguments = (input, options) => {
-  if (input instanceof Redis) return [input, normalizeOptions(options)]
+  if (input instanceof Redis) return input
   const { uri, ...opts } = Object.assign(
     typeof input === 'string' ? { uri: input } : input,
     options
   )
-  const normalizedOpts = normalizeOptions(opts)
-  return [new Redis(uri, normalizedOpts), normalizedOpts]
+  return new Redis(uri, opts)
 }
 
-class KeyvRedis extends EventEmitter {
+class KeyvRedis {
   constructor (uri, options) {
-    super()
-
-    const [redis, { emitErrors }] = normalizeArguments(uri, options)
-
+    const redis = normalizeArguments(uri, options)
     this.redis = redis
-
-    if (emitErrors) {
-      this.redis.on('error', error => {
-        this.emit('error', error)
-      })
-    }
   }
 
   async get (key) {

--- a/packages/sql/src/index.js
+++ b/packages/sql/src/index.js
@@ -1,16 +1,16 @@
-const EventEmitter = require('events')
+'use strict'
+
 const { Sql } = require('sql-ts')
-class KeyvSql extends EventEmitter {
+
+class KeyvSql {
   constructor (options) {
-    super()
     this.ttlSupport = false
 
     this.options = Object.assign(
       {
         table: 'keyv',
         keySize: 255,
-        iterationLimit: 10,
-        emitErrors: true
+        iterationLimit: 10
       },
       options
     )
@@ -31,27 +31,17 @@ class KeyvSql extends EventEmitter {
         }
       ]
     })
-    const createTable = this.entry
-      .create()
-      .ifNotExists()
-      .toString()
+    const createTable = this.entry.create().ifNotExists().toString()
 
     const connected = this.options
       .connect()
       .then(query => query(createTable).then(() => query))
-      .catch(error => {
-        if (this.options.emitErrors) {
-          this.emit('error', error)
-        }
-      })
+
     this.query = sqlString => connected.then(query => query(sqlString))
   }
 
   get (key) {
-    const select = this.entry
-      .select()
-      .where({ key })
-      .toString()
+    const select = this.entry.select().where({ key }).toString()
     return this.query(select).then(rows => {
       const row = rows[0]
       if (row === undefined) {
@@ -70,23 +60,17 @@ class KeyvSql extends EventEmitter {
     const upsert =
       this.options.dialect === 'postgres'
         ? this.entry
-            .insert({ key, value })
-            .onConflict({ columns: ['key'], update: ['value'] })
-            .toString()
+          .insert({ key, value })
+          .onConflict({ columns: ['key'], update: ['value'] })
+          .toString()
         : this.entry.replace({ key, value }).toString()
     return this.query(upsert)
   }
 
   delete (key) {
     if (!key) return false
-    const select = this.entry
-      .select()
-      .where({ key })
-      .toString()
-    const del = this.entry
-      .delete()
-      .where({ key })
-      .toString()
+    const select = this.entry.select().where({ key }).toString()
+    const del = this.entry.delete().where({ key }).toString()
     return this.query(select).then(rows => {
       const row = rows[0]
       if (row === undefined) {

--- a/packages/sqlite/src/index.d.ts
+++ b/packages/sqlite/src/index.d.ts
@@ -5,9 +5,8 @@
 // TypeScript Version: 2.3
 
 import { Store } from '@keyvhq/core'
-import { EventEmitter } from 'events'
 
-declare class KeyvSqlite extends EventEmitter implements Store<string | undefined> {
+declare class KeyvSqlite implements Store<string | undefined> {
   readonly ttlSupport: false
   namespace?: string | undefined
 

--- a/packages/test-suite/src/api.js
+++ b/packages/test-suite/src/api.js
@@ -125,32 +125,6 @@ const keyvApiTests = (test, Keyv, store) => {
     t.is(await keyv.has('foo'), false)
   })
 
-  test.serial('errors from stores get bubbled to keyv', async t => {
-    const keyvStore = store()
-
-    // Mock up an event emitter and fire it
-    if (typeof keyvStore.on !== 'function') {
-      keyvStore.eventHandlers = new Map()
-      keyvStore.on = function (event, callback) {
-        const callbacks = keyvStore.eventHandlers.get(event) || []
-        callbacks.push(callback)
-        keyvStore.eventHandlers.set(event, callbacks)
-      }
-      keyvStore.emit = function (event, ...data) {
-        const fns = keyvStore.eventHandlers.get(event) || []
-        for (const fn of fns) {
-          fn(...data)
-        }
-      }
-    }
-
-    const keyv = new Keyv({ store: keyvStore })
-
-    keyv.on('error', () => {
-      t.pass()
-    })
-    keyv.store.emit('error', 'foo')
-  })
   test.after.always(async () => {
     const keyv = new Keyv({ store: store() })
     await keyv.clear()


### PR DESCRIPTION
I was doubting what was the initial value proposition of extending store implementation of `EventEmitter` and I didn't find something that really justifies it, so probably it doesn't make sense to keep it. It's making the library less portable.