### PR TITLE
Use Keyv type for `KeyvMulti.Options` stores

### DIFF
--- a/packages/multi/src/index.d.ts
+++ b/packages/multi/src/index.d.ts
@@ -1,7 +1,7 @@
-import { Store } from '@keyvhq/core'
+import Keyv, { Store } from '@keyvhq/core'
 
 declare class KeyvMulti<TValue> implements Store<TValue> {
-  constructor (options: KeyvMulti.Options)
+  constructor (options: KeyvMulti.Options<TValue>)
 
   get (key: string): Promise<TValue>
   has (key: string): Promise<boolean>
@@ -12,9 +12,9 @@ declare class KeyvMulti<TValue> implements Store<TValue> {
 }
 
 declare namespace KeyvMulti {
-  interface Options {
-    local?: Map<string, any>
-    remote?: Map<string, any>
+  interface Options<TValue> {
+    local?: Keyv<TValue>
+    remote?: Keyv<TValue>
     validator?: () => boolean
   }
   interface ClearOptions {

--- a/packages/multi/test/index.test-d.ts
+++ b/packages/multi/test/index.test-d.ts
@@ -4,8 +4,8 @@ import Keyv from '@keyvhq/core'
 import KeyvMulti from '../src'
 
 const store = new KeyvMulti({
-  local: new Map(),
-  remote: new Map()
+  local: new Keyv(),
+  remote: new Keyv()
 })
 
 new Keyv({ store }).clear({ localOnly: true })


### PR DESCRIPTION
Closes https://github.com/microlinkhq/keyvhq/issues/210.

As described on https://github.com/microlinkhq/keyvhq/issues/210, the `remote`  and `local` types were incorrectly set to a JS Map (used by `Keyv` core under the hood). These types should be referencing [Keyv<TValue>](https://github.com/microlinkhq/keyvhq/blob/master/packages/core/src/index.d.ts#L1-L29) instead.

I also fixed the definition unit tests to pass a new Keyv instance for each store to reflect these changes.

A Keyv instance is used by default in the Multi class's constructor in case no override is set (not a Map): https://github.com/microlinkhq/keyvhq/blob/master/packages/multi/src/index.js#L6
