### PR TITLE
fix: build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,11 +265,6 @@
       "finepack"
     ]
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@vscode/sqlite3"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes pnpm install/build behavior by removing the `onlyBuiltDependencies` allowlist for `@vscode/sqlite3`, which could affect CI or local installs that rely on that native dependency being built.
> 
> **Overview**
> Removes the `pnpm.onlyBuiltDependencies` configuration from `package.json`, dropping the explicit allowlist entry for `@vscode/sqlite3` so pnpm no longer treats it as a special-case built dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6de86319f4b181a4b79dc09f40afe4da4cc21d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->