### PR TITLE
chore: add max-size package

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ You should also set a [`namespace`](#optionsnamespace) for your module so you ca
 ### Decorators
 
 - [@keyvhq/compress](https://github.com/microlinkhq/keyvhq/tree/master/packages/compress) – Adds compression bindings for your Keyv instance.
+- [@keyvhq/max-size](https://github.com/microlinkhq/keyvhq/tree/master/packages/max-size) – Skips storing values bigger than a configured payload size.
 - [@keyvhq/memoize](https://github.com/microlinkhq/keyvhq/tree/master/packages/memoize) – Memoize any function using Keyv as storage backend.
 - [@keyvhq/multi](https://github.com/microlinkhq/keyvhq/tree/master/packages/multi) – Manages local and remote keyv stores as one.
 - [@keyvhq/offline](https://github.com/microlinkhq/keyvhq/tree/master/packages/offline) – Adds offline capabilities for your keyv instance.

--- a/packages/max-size/CHANGELOG.md
+++ b/packages/max-size/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.2.0](https://github.com/microlinkhq/keyvhq) (2026-05-06)
+
+### Features
+
+* add max-size decorator for skipping oversized key writes

--- a/packages/max-size/README.md
+++ b/packages/max-size/README.md
@@ -1,0 +1,69 @@
+# @keyvhq/max-size [<img width="100" align="right" src="https://keyvhq.js.org/media/logo-sunset.svg" alt="keyv">](https://github.com/microlinkhq/keyvhq/tree/master/packages/max-size)
+
+> Prevents storing entries larger than a configured size in your Keyv instance.
+
+## Install
+
+```bash
+$ npm install @keyvhq/max-size --save
+```
+
+## Usage
+
+Wrap your [keyv](https://keyvhq.js.org) instance:
+
+```js
+const Keyv = require('@keyvhq/core')
+const KeyvRedis = require('@keyvhq/redis')
+const KeyvMaxSize = require('@keyvhq/max-size')
+
+const keyv = KeyvMaxSize(
+  new Keyv({
+    store: new KeyvRedis('redis://user:pass@localhost:6379')
+  }),
+  { maxSize: 1024 * 1024 } // required
+)
+```
+
+Values larger than `maxSize` are skipped and `.set()` resolves to `true`, preserving default Keyv behavior for callers.
+
+You can use it with [`bytes`](https://www.npmjs.com/package/bytes):
+
+```js
+const bytes = require('bytes')
+
+const keyv = KeyvMaxSize(new Keyv({ store }), {
+  maxSize: bytes('1KB')
+})
+```
+
+## API
+
+### KeyvMaxSize(keyv, [options])
+
+#### options.maxSize
+
+Type: `number`  
+Required: `true`
+
+Maximum serialized entry size in bytes.
+
+#### options.size
+
+Type: `(value, key) => number | Promise<number>`  
+Default: internal byte length calculator
+
+Custom byte size calculator.
+
+#### options.onSkip
+
+Type: `(context) => void | Promise<void>`
+
+Hook executed when a key is skipped due to size limit.
+
+## License
+
+**@keyvhq/max-size** © [Kiko Beats](https://kikobeats.com), released under the [MIT](https://github.com/microlinkhq/keyvhq/blob/master/LICENSE.md) License.<br/>
+Maintained by [Microlink](https://microlink.io) with help from [contributors](https://github.com/microlinkhq/keyvhq/contributors).
+
+> [microlink.io](https://microlink.io) · GitHub [microlinkhq](https://github.com/microlinkhq) · X [@microlinkhq](https://x.com/microlinkhq)

--- a/packages/max-size/package.json
+++ b/packages/max-size/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@keyvhq/max-size",
+  "description": "Prevents storing entries larger than a configured size in your Keyv instance.",
+  "homepage": "https://keyvhq.js.org",
+  "version": "2.2.0",
+  "types": "./src/index.d.ts",
+  "main": "src/index.js",
+  "author": {
+    "email": "hello@microlink.io",
+    "name": "microlink.io",
+    "url": "https://microlink.io"
+  },
+  "repository": {
+    "directory": "packages/max-size",
+    "type": "git",
+    "url": "git+https://github.com/microlinkhq/keyvhq.git"
+  },
+  "bugs": {
+    "url": "https://github.com/microlinkhq/keyvhq/issues"
+  },
+  "keywords": [
+    "cache",
+    "key",
+    "keyv",
+    "max",
+    "size",
+    "store",
+    "ttl",
+    "value"
+  ],
+  "dependencies": {
+    "debug-logfmt": "~1.4.7"
+  },
+  "devDependencies": {
+    "@keyvhq/compress": "workspace:*",
+    "@keyvhq/core": "workspace:*",
+    "ava": "5",
+    "bytes": "latest"
+  },
+  "engines": {
+    "node": ">= 18"
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "test": "ava"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/max-size/src/index.d.ts
+++ b/packages/max-size/src/index.d.ts
@@ -1,0 +1,26 @@
+import { Store } from '@keyvhq/core'
+
+interface KeyvMaxSizeSkipContext {
+  key: string
+  ttl?: number
+  value: unknown
+  maxSize: number
+  valueSize: number
+  namespace?: string
+}
+
+interface KeyvMaxSizeOptions {
+  maxSize: number
+  size?: (value: unknown, key?: string) => number | Promise<number>
+  onSkip?: (context: KeyvMaxSizeSkipContext) => void | Promise<void>
+}
+
+interface KeyvMaxSizeFactory {
+  <TValue>(keyv: Store<TValue>, opts: KeyvMaxSizeOptions): Store<TValue>
+  new <TValue>(keyv: Store<TValue>, opts: KeyvMaxSizeOptions): Store<TValue>
+  byteLength: (value: unknown) => number
+}
+
+declare const KeyvMaxSize: KeyvMaxSizeFactory
+
+export = KeyvMaxSize

--- a/packages/max-size/src/index.js
+++ b/packages/max-size/src/index.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const debug = require('debug-logfmt')('keyv-max-size')
+
+const byteLength = value => {
+  if (typeof value === 'string') return Buffer.byteLength(value)
+  if (Buffer.isBuffer(value)) return value.byteLength
+  if (value instanceof ArrayBuffer) return value.byteLength
+  if (ArrayBuffer.isView(value)) return value.byteLength
+  const payload = JSON.stringify(value)
+  return payload === undefined ? 0 : Buffer.byteLength(payload)
+}
+
+function KeyvMaxSize (keyv, { maxSize, size = byteLength, onSkip } = {}) {
+  if (!(this instanceof KeyvMaxSize)) {
+    return new KeyvMaxSize(keyv, { maxSize, size, onSkip })
+  }
+
+  if (!keyv || !keyv.store || typeof keyv.store.set !== 'function') {
+    throw new TypeError('A keyv instance with a writable store is required.')
+  }
+
+  if (!Number.isFinite(maxSize) || maxSize <= 0) {
+    throw new TypeError('`maxSize` must be provided as a positive number.')
+  }
+
+  const set = keyv.store.set.bind(keyv.store)
+
+  keyv.store.set = async (key, value, ttl) => {
+    const valueSize = await size(value, key)
+
+    if (!Number.isFinite(valueSize) || valueSize < 0) {
+      throw new TypeError('`size` function must return a positive number.')
+    }
+
+    if (valueSize > maxSize) {
+      const context = {
+        key,
+        ttl,
+        value,
+        maxSize,
+        valueSize,
+        namespace: keyv.namespace
+      }
+
+      debug('skipped', {
+        key,
+        ttl,
+        maxSize,
+        valueSize,
+        namespace: keyv.namespace
+      })
+
+      if (typeof onSkip === 'function') await onSkip(context)
+
+      return true
+    }
+
+    return set(key, value, ttl)
+  }
+
+  return keyv
+}
+
+module.exports = KeyvMaxSize
+module.exports.byteLength = byteLength

--- a/packages/max-size/test/index.js
+++ b/packages/max-size/test/index.js
@@ -1,0 +1,122 @@
+'use strict'
+
+const keyvCompress = require('@keyvhq/compress')
+const Keyv = require('@keyvhq/core')
+const bytes = require('bytes')
+const test = require('ava')
+
+const KeyvMaxSize = require('..')
+const { byteLength } = KeyvMaxSize
+
+test('byteLength handles string values', t => {
+  t.is(byteLength('hello'), Buffer.byteLength('hello'))
+})
+
+test('byteLength handles Buffer values', t => {
+  const value = Buffer.from('hello')
+  t.is(byteLength(value), value.byteLength)
+})
+
+test('byteLength handles typed arrays', t => {
+  const value = new Uint8Array([1, 2, 3, 4, 5])
+  t.is(byteLength(value), value.byteLength)
+})
+
+test('byteLength handles object values', t => {
+  const value = { hello: 'world' }
+  t.is(byteLength(value), Buffer.byteLength(JSON.stringify(value)))
+})
+
+test('byteLength returns 0 for undefined', t => {
+  t.is(byteLength(undefined), 0)
+})
+
+test('.set stores values smaller than maxSize', async t => {
+  const store = new Map()
+  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
+    maxSize: 128
+  })
+
+  t.true(await keyv.set('foo', 'bar'))
+  t.true(store.has('foo'))
+  t.is(await keyv.get('foo'), 'bar')
+})
+
+test('throws when maxSize is not provided', t => {
+  const store = new Map()
+  const keyv = new Keyv({ store, namespace: null })
+
+  const error = t.throws(() => KeyvMaxSize(keyv), { instanceOf: TypeError })
+  t.is(error.message, '`maxSize` must be provided as a positive number.')
+})
+
+test('.set skips values larger than maxSize', async t => {
+  const store = new Map()
+  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
+    maxSize: 32
+  })
+
+  t.true(await keyv.set('foo', 'this-is-bigger-than-8-bytes'))
+  t.false(store.has('foo'))
+  t.is(await keyv.get('foo'), undefined)
+})
+
+test('onSkip receives skip context', async t => {
+  const store = new Map()
+  const skipped = []
+
+  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
+    maxSize: 32,
+    onSkip: context => {
+      skipped.push(context)
+    }
+  })
+
+  await keyv.set('foo', 'this-is-bigger-than-8-bytes')
+
+  t.is(skipped.length, 1)
+  t.is(skipped[0].key, 'foo')
+  t.is(skipped[0].maxSize, 32)
+  t.true(skipped[0].valueSize > 32)
+})
+
+test('custom size calculator can be used', async t => {
+  const store = new Map()
+
+  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
+    maxSize: 1,
+    size: () => 1
+  })
+
+  await keyv.set('foo', 'this-is-bigger-than-1-byte')
+
+  t.true(store.has('foo'))
+})
+
+test('accepts maxSize from bytes helper', async t => {
+  const store = new Map()
+  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
+    maxSize: bytes('1KB')
+  })
+
+  await keyv.set('small', 'a'.repeat(64))
+  await keyv.set('big', 'a'.repeat(2048))
+
+  t.true(store.has('small'))
+  t.false(store.has('big'))
+})
+
+test('works with compressed serialization', async t => {
+  const store = new Map()
+  const payload = 'a'.repeat(10000)
+
+  const keyv = KeyvMaxSize(
+    keyvCompress(new Keyv({ store, namespace: null })),
+    { maxSize: 128 }
+  )
+
+  await keyv.set('foo', payload)
+
+  t.true(store.has('foo'))
+  t.is(await keyv.get('foo'), payload)
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: change is additive (new `@keyvhq/max-size` package plus docs) and doesn’t modify existing core/adapter behavior unless explicitly wrapped by consumers.
> 
> **Overview**
> Adds new decorator package `@keyvhq/max-size` that wraps a Keyv instance and enforces a maximum serialized payload size by intercepting `.store.set`, skipping oversized writes while still resolving `.set()` to `true` (with optional `onSkip` hook and debug logging).
> 
> Includes TypeScript typings, unit tests covering size calculation and skip behavior (including compatibility with `@keyvhq/compress`), and updates the main `README.md` to list the new decorator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a10422d03bf83afd643eecbcdca591a72bcd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->