### PR TITLE
chore(max-size): simplify API

### DIFF
--- a/packages/max-size/README.md
+++ b/packages/max-size/README.md
@@ -1,6 +1,6 @@
 # @keyvhq/max-size [<img width="100" align="right" src="https://keyvhq.js.org/media/logo-sunset.svg" alt="keyv">](https://github.com/microlinkhq/keyvhq/tree/master/packages/max-size)
 
-> Prevents storing entries larger than a configured size in your Keyv instance.
+> Prevents storing entries larger than a configured size.
 
 ## Install
 
@@ -10,17 +10,14 @@ $ npm install @keyvhq/max-size --save
 
 ## Usage
 
-Wrap your [keyv](https://keyvhq.js.org) instance:
+Wrap your store:
 
 ```js
-const Keyv = require('@keyvhq/core')
 const KeyvRedis = require('@keyvhq/redis')
 const KeyvMaxSize = require('@keyvhq/max-size')
 
-const keyv = KeyvMaxSize(
-  new Keyv({
-    store: new KeyvRedis('redis://user:pass@localhost:6379')
-  }),
+const store = new KeyvMaxSize(
+  new KeyvRedis('redis://user:pass@localhost:6379'),
   { maxSize: 1024 * 1024 } // required
 )
 ```
@@ -32,14 +29,21 @@ You can use it with [`bytes`](https://www.npmjs.com/package/bytes):
 ```js
 const bytes = require('bytes')
 
-const keyv = KeyvMaxSize(new Keyv({ store }), {
+const store = new KeyvMaxSize(redisStore, {
   maxSize: bytes('1KB')
 })
 ```
 
 ## API
 
-### KeyvMaxSize(keyv, [options])
+### KeyvMaxSize(store, [options])
+
+#### store
+
+Type: `object`  
+Required: `true`
+
+A store instance with a `set` method (e.g., `KeyvRedis`, `Map`).
 
 #### options.maxSize
 

--- a/packages/max-size/src/index.d.ts
+++ b/packages/max-size/src/index.d.ts
@@ -6,7 +6,6 @@ interface KeyvMaxSizeSkipContext {
   value: unknown
   maxSize: number
   valueSize: number
-  namespace?: string
 }
 
 interface KeyvMaxSizeOptions {

--- a/packages/max-size/src/index.js
+++ b/packages/max-size/src/index.js
@@ -15,12 +15,12 @@ const byteLength = value => {
   return payload === undefined ? 0 : Buffer.byteLength(payload)
 }
 
-function KeyvMaxSize (store, { maxSize, size = byteLength, onSkip } = {}) {
+function KeyvMaxSize (keyv, { maxSize, size = byteLength, onSkip } = {}) {
   if (!(this instanceof KeyvMaxSize)) {
-    return new KeyvMaxSize(store, { maxSize, size, onSkip })
+    return new KeyvMaxSize(keyv, { maxSize, size, onSkip })
   }
 
-  if (!store || typeof store.set !== 'function') {
+  if (!keyv || typeof keyv.set !== 'function') {
     throw new TypeError('A store with a `set` method is required.')
   }
 
@@ -28,9 +28,9 @@ function KeyvMaxSize (store, { maxSize, size = byteLength, onSkip } = {}) {
     throw new TypeError('`maxSize` must be provided as a positive number.')
   }
 
-  const set = store.set.bind(store)
+  const set = keyv.set.bind(keyv)
 
-  store.set = async (key, value, ttl) => {
+  keyv.set = async (key, value, ttl) => {
     const valueSize = await size(value, key)
 
     if (!Number.isFinite(valueSize) || valueSize < 0) {
@@ -46,7 +46,7 @@ function KeyvMaxSize (store, { maxSize, size = byteLength, onSkip } = {}) {
     return set(key, value, ttl)
   }
 
-  return store
+  return keyv
 }
 
 module.exports = KeyvMaxSize

--- a/packages/max-size/src/index.js
+++ b/packages/max-size/src/index.js
@@ -15,22 +15,22 @@ const byteLength = value => {
   return payload === undefined ? 0 : Buffer.byteLength(payload)
 }
 
-function KeyvMaxSize (keyv, { maxSize, size = byteLength, onSkip } = {}) {
+function KeyvMaxSize (store, { maxSize, size = byteLength, onSkip } = {}) {
   if (!(this instanceof KeyvMaxSize)) {
-    return new KeyvMaxSize(keyv, { maxSize, size, onSkip })
+    return new KeyvMaxSize(store, { maxSize, size, onSkip })
   }
 
-  if (!keyv || !keyv.store || typeof keyv.store.set !== 'function') {
-    throw new TypeError('A keyv instance with a writable store is required.')
+  if (!store || typeof store.set !== 'function') {
+    throw new TypeError('A store with a `set` method is required.')
   }
 
   if (!Number.isFinite(maxSize) || maxSize <= 0) {
     throw new TypeError('`maxSize` must be provided as a positive number.')
   }
 
-  const set = keyv.store.set.bind(keyv.store)
+  const set = store.set.bind(store)
 
-  keyv.store.set = async (key, value, ttl) => {
+  store.set = async (key, value, ttl) => {
     const valueSize = await size(value, key)
 
     if (!Number.isFinite(valueSize) || valueSize < 0) {
@@ -38,32 +38,15 @@ function KeyvMaxSize (keyv, { maxSize, size = byteLength, onSkip } = {}) {
     }
 
     if (valueSize > maxSize) {
-      const context = {
-        key,
-        ttl,
-        value,
-        maxSize,
-        valueSize,
-        namespace: keyv.namespace
-      }
-
-      debug('skipped', {
-        key,
-        ttl,
-        maxSize,
-        valueSize,
-        namespace: keyv.namespace
-      })
-
-      if (typeof onSkip === 'function') await onSkip(context)
-
+      debug('skipped', { key, ttl, maxSize, valueSize })
+      if (typeof onSkip === 'function') await onSkip({ key, ttl, value, maxSize, valueSize })
       return true
     }
 
     return set(key, value, ttl)
   }
 
-  return keyv
+  return store
 }
 
 module.exports = KeyvMaxSize

--- a/packages/max-size/test/index.js
+++ b/packages/max-size/test/index.js
@@ -33,9 +33,7 @@ test('byteLength returns 0 for undefined', t => {
 
 test('.set stores values smaller than maxSize', async t => {
   const store = new Map()
-  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
-    maxSize: 128
-  })
+  const keyv = new Keyv({ store: new KeyvMaxSize(store, { maxSize: 128 }), namespace: null })
 
   t.true(await keyv.set('foo', 'bar'))
   t.true(store.has('foo'))
@@ -44,17 +42,18 @@ test('.set stores values smaller than maxSize', async t => {
 
 test('throws when maxSize is not provided', t => {
   const store = new Map()
-  const keyv = new Keyv({ store, namespace: null })
-
-  const error = t.throws(() => KeyvMaxSize(keyv), { instanceOf: TypeError })
+  const error = t.throws(() => new KeyvMaxSize(store), { instanceOf: TypeError })
   t.is(error.message, '`maxSize` must be provided as a positive number.')
+})
+
+test('throws when store is invalid', t => {
+  const error = t.throws(() => new KeyvMaxSize(null, { maxSize: 128 }), { instanceOf: TypeError })
+  t.is(error.message, 'A store with a `set` method is required.')
 })
 
 test('.set skips values larger than maxSize', async t => {
   const store = new Map()
-  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
-    maxSize: 32
-  })
+  const keyv = new Keyv({ store: new KeyvMaxSize(store, { maxSize: 32 }), namespace: null })
 
   t.true(await keyv.set('foo', 'this-is-bigger-than-8-bytes'))
   t.false(store.has('foo'))
@@ -65,11 +64,12 @@ test('onSkip receives skip context', async t => {
   const store = new Map()
   const skipped = []
 
-  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
-    maxSize: 32,
-    onSkip: context => {
-      skipped.push(context)
-    }
+  const keyv = new Keyv({
+    store: new KeyvMaxSize(store, {
+      maxSize: 32,
+      onSkip: context => skipped.push(context)
+    }),
+    namespace: null
   })
 
   await keyv.set('foo', 'this-is-bigger-than-8-bytes')
@@ -82,21 +82,20 @@ test('onSkip receives skip context', async t => {
 
 test('custom size calculator can be used', async t => {
   const store = new Map()
-
-  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
-    maxSize: 1,
-    size: () => 1
+  const keyv = new Keyv({
+    store: new KeyvMaxSize(store, { maxSize: 1, size: () => 1 }),
+    namespace: null
   })
 
   await keyv.set('foo', 'this-is-bigger-than-1-byte')
-
   t.true(store.has('foo'))
 })
 
 test('accepts maxSize from bytes helper', async t => {
   const store = new Map()
-  const keyv = KeyvMaxSize(new Keyv({ store, namespace: null }), {
-    maxSize: bytes('1KB')
+  const keyv = new Keyv({
+    store: new KeyvMaxSize(store, { maxSize: bytes('1KB') }),
+    namespace: null
   })
 
   await keyv.set('small', 'a'.repeat(64))
@@ -110,10 +109,10 @@ test('works with compressed serialization', async t => {
   const store = new Map()
   const payload = 'a'.repeat(10000)
 
-  const keyv = KeyvMaxSize(
-    keyvCompress(new Keyv({ store, namespace: null })),
-    { maxSize: 128 }
-  )
+  const keyv = keyvCompress(new Keyv({
+    store: new KeyvMaxSize(store, { maxSize: 128 }),
+    namespace: null
+  }))
 
   await keyv.set('foo', payload)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public API shape (now wraps a store’s `set` instead of a `Keyv` instance’s `store.set`), which can break existing integrations and subtly affect behavior depending on store implementations.
> 
> **Overview**
> Simplifies `@keyvhq/max-size` to wrap a *store* directly: it now expects an object with a `set` method, overrides `store.set`, and is intended to be passed into `new Keyv({ store })` rather than wrapping a full `Keyv` instance.
> 
> The skip context/logging is streamlined (drops `namespace`), docs are updated to the new usage, and tests are rewritten to construct `Keyv` with a `KeyvMaxSize`-wrapped store plus a new validation test for invalid stores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d16b0a678234a0d0be4f7bd35e4b10bbb50dd49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->