### PR TITLE
chore: update dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,7 @@
 audit=false
 fund=false
 loglevel=error
-package-lock=false
+lockfile=false
 prefer-dedupe=true
 prefer-offline=false
 resolution-mode=highest

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -30,7 +30,7 @@
     "value"
   ],
   "dependencies": {
-    "ioredis": "~5.10.0"
+    "ioredis": "~5.11.0"
   },
   "devDependencies": {
     "@keyvhq/core": "workspace:*",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level dependency bump and a config key rename with no logic changes in the redis package.
> 
> **Overview**
> Updates **@keyvhq/redis** to depend on **ioredis** `~5.11.0` (from `~5.10.0`). No adapter source changes—only the declared runtime dependency version.
> 
> In **`.npmrc`**, replaces the deprecated `package-lock=false` setting with **`lockfile=false`**, keeping the same intent (don’t write lockfiles on install) under current npm/pnpm option names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556ff15cece59ff5c2514626e4c76ef36fbf7fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->