### PR TITLE
fix(memoize): skip stale fast-path on forced expiration

### DIFF
--- a/packages/memoize/src/index.js
+++ b/packages/memoize/src/index.js
@@ -82,7 +82,7 @@ function memoize (
         updateStoredValue(key, value)
       )
 
-      if (isStale) {
+      if (isStale && !isExpired) {
         promise
           .then(() => (pending[key] = undefined))
           .catch(error => (info.staleError = error))

--- a/packages/memoize/test/index.js
+++ b/packages/memoize/test/index.js
@@ -289,6 +289,37 @@ test('should accept `staleTtl` as function', async t => {
   t.true(infoTwo.hasValue)
 })
 
+test('should return fresh result when force expiration during stale window', async t => {
+  let index = 0
+
+  const store = new Map()
+  const fn = () => ++index
+  const key = ({ key, forceExpiration }) => [key, forceExpiration]
+
+  const memoizeFn = memoize(fn, store, {
+    ttl: 100,
+    staleTtl: 80,
+    key,
+    objectMode: true
+  })
+
+  const [valueOne] = await memoizeFn({ key: 'foo', forceExpiration: false })
+  t.is(valueOne, 1)
+
+  await setTimeout(25)
+
+  const [valueTwo, infoTwo] = await memoizeFn({ key: 'foo', forceExpiration: false })
+  t.is(valueTwo, 1)
+  t.true(infoTwo.isStale)
+
+  await setTimeout(5)
+
+  const [valueThree, infoThree] = await memoizeFn({ key: 'foo', forceExpiration: true })
+  t.true(infoThree.isExpired)
+  t.not(valueThree, 1)
+  t.is(valueThree, index)
+})
+
 test('should be possible force expiration', async t => {
   let index = 0
 


### PR DESCRIPTION
Stale-while-revalidate returned cached data even when forceExpiration was true, because the `isStale` check didn't account for `isExpired`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in memoize TTL/stale logic with a targeted regression test; no security or data-layer changes.
> 
> **Overview**
> Fixes **stale-while-revalidate** so **`forceExpiration: true`** no longer returns the cached value while revalidating in the background.
> 
> The stale fast-path condition is tightened from `isStale` to **`isStale && !isExpired`**, so forced expiration skips returning stale data and **awaits a fresh `fn(...)` result** instead. A new test covers forcing expiration during the stale window and expects a new value with `isExpired` set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6add1ec8acf6f5e5498b7ffff9ee634f67667948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->