### PR TITLE
fix(compress): correct type definitions to match implementation

### DIFF
--- a/packages/compress/src/index.d.ts
+++ b/packages/compress/src/index.d.ts
@@ -1,15 +1,17 @@
-import { Store } from '@keyvhq/core'
+import Keyv from '@keyvhq/core'
 
-declare class KeyvCompress<TValue> {
-  constructor (keyv: Store<TValue>, opts?: KeyvCompress.Options)
-}
+declare function KeyvCompress<TValue = any> (
+  keyv: Keyv<TValue>,
+  opts?: KeyvCompress.Options
+): Keyv<TValue>
 
 declare namespace KeyvCompress {
   interface Options {
-    serialize?: (data: { value: unknown; expires: number | null }) => string
-    deserialize?: (data: string) => { value: unknown; expires: number | null }
-    compress?: (value: unknown) => Promise<unknown>
-    decompress?: (value: unknown) => Promise<unknown>
+    enable?: boolean
+    serialize?: (source: any) => any
+    deserialize?: (source: any) => any
+    compressOptions?: Record<string, any>
+    decompressOptions?: Record<string, any>
   }
 }
 


### PR DESCRIPTION
Was declared as class taking Store; actually a function taking Keyv that returns the mutated Keyv instance. Options now match compress-brotli API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Declaration-only change; no runtime or behavioral impact, only improves TypeScript accuracy for consumers.
> 
> **Overview**
> Aligns `@keyvhq/compress` **TypeScript declarations** with the real API: `KeyvCompress` is typed as a **function** that accepts a `Keyv` instance (not a `Store`) and **returns** that same `Keyv` after wiring compression into `serialize`/`deserialize`.
> 
> The `Options` shape is updated to mirror **compress-brotli** (`enable`, generic serialize/deserialize, `compressOptions` / `decompressOptions`) instead of the old custom compress/decompress hooks and `{ value, expires }`-specific serializers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f030d2f801fdda8a9ce3440ded70625d23308f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->