### PR TITLE
fix(memoize): isolate force bypass and recover stuck pending during stale window

### DIFF
--- a/packages/memoize/src/index.js
+++ b/packages/memoize/src/index.js
@@ -56,10 +56,11 @@ function memoize (
   function memoized (...args) {
     const rawKey = getKey(...args)
     const [key, forceExpiration] = Array.isArray(rawKey) ? rawKey : [rawKey]
+    const pendingKey = `${key}:${forceExpiration === true}`
 
-    if (pending[key] !== undefined) return pending[key]
+    if (pending[pendingKey] !== undefined) return pending[pendingKey]
 
-    pending[key] = getRaw(key).then(async data => {
+    pending[pendingKey] = getRaw(key).then(async data => {
       const hasValue = data ? data.value !== undefined : false
       const hasExpires = hasValue && typeof data.expires === 'number'
       const ttlValue = hasExpires ? data.expires - Date.now() : undefined
@@ -74,35 +75,38 @@ function memoize (
       const done = value => (objectMode ? [value, info] : value)
 
       if (hasValue && !isExpired && !isStale) {
-        pending[key] = undefined
+        pending[pendingKey] = undefined
         return done(data.value)
       }
 
-      const promise = Promise.resolve(fn(...args)).then(value =>
-        updateStoredValue(key, value)
-      )
+      const promise = Promise.resolve()
+        .then(() => fn(...args))
+        .then(value => updateStoredValue(key, value))
 
       if (isStale && !isExpired) {
         promise
-          .then(() => (pending[key] = undefined))
-          .catch(error => (info.staleError = error))
+          .then(() => (pending[pendingKey] = undefined))
+          .catch(error => {
+            pending[pendingKey] = undefined
+            info.staleError = error
+          })
         return done(data.value)
       }
 
       try {
         const value = await promise
-        pending[key] = undefined
+        pending[pendingKey] = undefined
         return done(value)
       } catch (error) {
-        pending[key] = undefined
+        pending[pendingKey] = undefined
         throw error
       }
     }).catch(error => {
-      pending[key] = undefined
+      pending[pendingKey] = undefined
       throw error
     })
 
-    return pending[key]
+    return pending[pendingKey]
   }
 
   mimicFn(memoized, fn)

--- a/packages/memoize/test/index.js
+++ b/packages/memoize/test/index.js
@@ -182,6 +182,7 @@ test('should emit on stale refresh error', async t => {
   await keyv.set(1, 1, 5)
   const [, info] = await memoizedSum(1)
 
+  await setTimeout(10)
   t.is(info.staleError.message, 'NOPE')
 })
 
@@ -348,4 +349,105 @@ test('should be possible force expiration', async t => {
   })
 
   t.is(valueThree, 2)
+})
+
+test('should return fresh result when force expiration concurrently during stale window', async t => {
+  let index = 0
+
+  const store = new Map()
+  const fn = () => ++index
+  const key = ({ key, forceExpiration }) => [key, forceExpiration]
+
+  const memoizeFn = memoize(fn, store, {
+    ttl: 100,
+    staleTtl: 80,
+    key,
+    objectMode: true
+  })
+
+  const [valueOne] = await memoizeFn({ key: 'foo', forceExpiration: false })
+  t.is(valueOne, 1)
+
+  await setTimeout(25)
+
+  const [[valueNormal, infoNormal], [valueForce, infoForce]] = await Promise.all([
+    memoizeFn({ key: 'foo', forceExpiration: false }),
+    memoizeFn({ key: 'foo', forceExpiration: true })
+  ])
+
+  t.is(valueNormal, 1)
+  t.true(infoNormal.isStale)
+
+  t.true(infoForce.isExpired)
+  t.not(valueForce, 1)
+})
+
+test('should retry origin after a stale refresh failure', async t => {
+  let index = 0
+  let healthy = true
+
+  const store = new Map()
+  const fn = () => {
+    index++
+    if (!healthy) throw new Error('origin down')
+    return index
+  }
+  const key = ({ key }) => [key]
+
+  const memoizeFn = memoize(fn, store, {
+    ttl: 200,
+    staleTtl: 150,
+    key,
+    objectMode: true
+  })
+
+  const [first] = await memoizeFn({ key: 'foo' })
+  t.is(first, 1)
+
+  await setTimeout(60)
+
+  healthy = false
+  const [stale, info] = await memoizeFn({ key: 'foo' })
+  t.is(stale, 1)
+  t.true(info.isStale)
+  await setTimeout(20)
+  t.is(info.staleError.message, 'origin down')
+
+  healthy = true
+  const [stillStale, infoTwo] = await memoizeFn({ key: 'foo' })
+  t.is(stillStale, 1)
+  t.true(infoTwo.isStale)
+  await setTimeout(20)
+
+  const [fresh] = await memoizeFn({ key: 'foo' })
+  t.is(fresh, 3)
+})
+
+test('should serve stale result when refresh throws synchronously', async t => {
+  let calls = 0
+
+  const store = new Map()
+  const fn = () => {
+    if (++calls > 1) throw new Error('NOPE')
+    return calls
+  }
+  const key = ({ key }) => [key]
+
+  const memoizeFn = memoize(fn, store, {
+    ttl: 200,
+    staleTtl: 150,
+    key,
+    objectMode: true
+  })
+
+  const [first] = await memoizeFn({ key: 'foo' })
+  t.is(first, 1)
+
+  await setTimeout(60)
+
+  const [stale, info] = await memoizeFn({ key: 'foo' })
+  t.is(stale, 1)
+  t.true(info.isStale)
+  await setTimeout(20)
+  t.is(info.staleError.message, 'NOPE')
 })


### PR DESCRIPTION
> **Follow-up to #266.** That PR fixed the *sequential* force-during-stale case by tightening the fast-path to `isStale && !isExpired`. This PR fixes the case that guard can't reach — when a `?force=true` request is coalesced onto another request's in-flight `pending` entry and never evaluates `isExpired` at all.

## Background

Three stale-while-revalidate correctness bugs live in `@keyvhq/memoize`'s in-flight dedup (`pending`). They surface under concurrency in `cacheable-response` (`?force=true` cache invalidation, SWR refresh failures). #266 closed the sequential force-after-stale gap, but its `!isExpired` guard only fires when the force request actually runs the fast-path — under concurrency it never gets the chance.

## Bugs & fixes (`packages/memoize/src/index.js`)

1. **Concurrent force-bypass race** — `pending` was keyed by `key` only, so a `?force=true` request arriving while a normal request held the stale fast-path coalesced onto it and inherited the stale value (`forceExpiration: false`), bypassing #266's guard entirely. Now keyed by the force flag: `` `${key}:${forceExpiration === true}` ``, so the force request gets its own evaluation.

2. **Stuck pending after refresh failure** — in the stale fast-path, `pending` was cleared only on `.then()`. A rejected background refresh left the resolved stale promise pinned, so every later request reused it and never retried the origin (stale until restart). Now cleared in `.catch()` too.

3. **Synchronous throw escapes the fast-path** — `Promise.resolve(fn(...args))` runs `fn` eagerly, so a synchronous throw rejected the whole memoized call instead of being served stale. Deferred via `Promise.resolve().then(() => fn(...args))`, aligning sync-throw behavior with async-reject.

## Tests (`packages/memoize/test/index.js`)

- `should return fresh result when force expiration concurrently during stale window`
- `should retry origin after a stale refresh failure`
- `should serve stale result when refresh throws synchronously`

Also updated the existing `should emit on stale refresh error`: it read `info.staleError` synchronously, but the background refresh now (correctly) settles a microtask later, so it awaits first.

**`npx ava` → 26/26 pass; `standard` lint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
