### PR TITLE
fix(ci): pin TypeScript so ts-standard can load

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "ava": "5",
     "timekeeper": "latest",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "ava": "5",
     "timekeeper": "latest",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -36,7 +36,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -36,7 +36,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -40,7 +40,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -40,7 +40,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/multi/package.json
+++ b/packages/multi/package.json
@@ -36,7 +36,7 @@
     "@keyvhq/sqlite": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/multi/package.json
+++ b/packages/multi/package.json
@@ -36,7 +36,7 @@
     "@keyvhq/sqlite": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -41,7 +41,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -41,7 +41,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/offline/src/index.d.ts
+++ b/packages/offline/src/index.d.ts
@@ -1,8 +1,8 @@
 import { Store } from '@keyvhq/core'
 
-declare class KeyvOffline<TValue> {
-  constructor (keyv: Store<TValue>)
-}
+declare function KeyvOffline<TValue> (
+  keyv: Store<TValue>
+): Store<TValue>
 
 declare namespace KeyvOffline {
   // No additional options for this adapter

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -41,7 +41,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -41,7 +41,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -39,7 +39,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -39,7 +39,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -41,7 +41,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -41,7 +41,7 @@
     "@types/node": "latest",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -29,7 +29,7 @@
     "@keyvhq/file": "workspace:*",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "latest"
+    "typescript": "~5.9.3"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -29,7 +29,7 @@
     "@keyvhq/file": "workspace:*",
     "ava": "5",
     "tsd": "latest",
-    "typescript": "~5.9.3"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - 'packages/*'
+
+overrides:
+  typescript: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@ packages:
   - 'packages/*'
 
 overrides:
-  typescript: 5.9.3
+  typescript: '5'


### PR DESCRIPTION
## Summary
- The [lint job on master](https://github.com/microlinkhq/keyvhq/actions/runs/30849508493/job/91805833869) failed because `typescript@7` broke `ts-standard`'s `@typescript-eslint@5` (`Cannot read properties of undefined (reading 'Any')`)
- Pin `typescript` to `~5.9.3` (packages + workspace override) and fix `@keyvhq/offline` typings to match the factory-function implementation

## Test plan
- [ ] CI lint job passes
- [ ] Master release pipeline is no longer blocked on lint


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the development environment on TypeScript 5.9.3 across all packages.
  * Added a workspace-level version override to ensure consistent TypeScript tooling.
* **Refactor**
  * Updated the offline store’s public declaration to expose a generic store-compatible function interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->